### PR TITLE
Slight cleanup in algebra

### DIFF
--- a/src/adem_algebra.rs
+++ b/src/adem_algebra.rs
@@ -131,15 +131,6 @@ impl Algebra for AdemAlgebra {
         self.p
     }
 
-    fn get_max_degree(&self) -> i32 {
-        // for i in 0..self.basis_table.len() {
-        //     if !self.basis_table[i].has() {
-        //         return i as i32;
-        //     }
-        // }
-        return self.basis_table.len() as i32;
-    }
-
     fn get_name(&self) -> &str {
         &self.name
     }
@@ -309,6 +300,10 @@ impl AdemAlgebra {
             sort_order : None,
             filtration_one_products
         }
+    }
+
+    fn get_max_degree(&self) -> i32 {
+        return self.basis_table.len() as i32;
     }
 
     fn generate_basis_even(&self, mut old_max_degree : i32, max_degree : i32){

--- a/src/algebra.rs
+++ b/src/algebra.rs
@@ -3,7 +3,6 @@ use serde_json::value::Value;
 
 pub trait Algebra {
     fn get_prime(&self) -> u32;
-    fn get_max_degree(&self) -> i32; 
     fn get_name(&self) -> &str;
     // FiltrationOneProductList *product_list; // This determines which indecomposibles have lines drawn for them.
 // Methods:

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,6 @@ use serde_json::value::Value;
 
 use crate::algebra::Algebra;
 use crate::adem_algebra::AdemAlgebra;
-#[cfg(test)]
 use crate::milnor_algebra::MilnorAlgebra;
 use crate::finite_dimensional_module::FiniteDimensionalModule;
 use crate::chain_complex::ChainComplexConcentratedInDegreeZero;
@@ -46,47 +45,73 @@ fn main() {
         std::process::exit(1);
     });
 
-    if let Err(e) = run(config) {
-        eprintln!("Application error: {}", e);
-        std::process::exit(1);
+    match run(config) {
+        Ok(string) => println!("{}", string),
+        Err(e) => { eprintln!("Application error: {}", e); std::process::exit(1); }
     }
 }
 
 #[allow(non_snake_case)]
-fn run(config : Config) -> Result<(), Box<Error>> {
+fn run(config : Config) -> Result<String, Box<Error>> {
     let contents = std::fs::read_to_string(format!("static/modules/{}.json", config.module_name))?;
     let mut json : Value = serde_json::from_str(&contents)?;
     let p = json["p"].as_u64().unwrap() as u32;
     let max_degree = config.max_degree;
 
-    let A = AdemAlgebra::new(p, p != 2, false, max_degree);
+    // You need a box in order to allow for different possible types implementing the same
+    // trait
+    let A : Box<Algebra>;
+    match config.algebra_name.as_ref() {
+        "adem" => A = Box::new(AdemAlgebra::new(p, p != 2, false, max_degree)),
+        "milnor" => A = Box::new(MilnorAlgebra::new(p)),
+        _ => { println!("Invalid algebra"); return Err(Box::new(InvalidAlgebraError { name : config.algebra_name })); }
+    };
+
     A.compute_basis(max_degree);
-    let M = FiniteDimensionalModule::from_json(&A, "adem", &mut json);
+    let M = FiniteDimensionalModule::from_json(&*A, &config.algebra_name, &mut json);
     let CC = ChainComplexConcentratedInDegreeZero::new(&M);
     let res = Resolution::new(&CC, max_degree, None, None);
     res.resolve_through_degree(max_degree);
-    println!("{}", res.graded_dimension_string());
-    Ok(())
+    Ok(res.graded_dimension_string())
 }
 
 struct Config {
     module_name : String,
+    algebra_name : String,
     max_degree : i32
 }
 
 impl Config {
     fn new(args: &[String]) -> Result<Self, String> {
-        if args.len() < 3 {
+        if args.len() < 4 {
             return Err("Not enough arguments".to_string());
         }
         let module_name = args[1].clone();
-        let max_deg_result : Result<i32,_> = args[2].parse();
+        let algebra_name = args[2].clone();
+        let max_deg_result : Result<i32,_> = args[3].parse();
 
         if let Err(error) = max_deg_result {
             return Err(format!("{} in argument max_degree.", error));
         }
         let max_degree = max_deg_result.unwrap();
-        Ok(Self { module_name, max_degree })
+        Ok(Self { module_name, algebra_name, max_degree })
+    }
+}
+
+#[derive(Debug)]
+struct InvalidAlgebraError {
+    name : String
+}
+
+impl std::fmt::Display for InvalidAlgebraError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Invalid algebra: {}", &self.name)
+    }
+}
+
+impl Error for InvalidAlgebraError {
+    fn description(&self) -> &str {
+        "Invalid algebra supplied"
     }
 }
 
@@ -107,38 +132,22 @@ mod tests {
         compare("C3", 60);
     }
 
-    fn compare(filename : &str, max_degree : i32) {
-        let contents = std::fs::read_to_string(format!("static/modules/{}.json", filename)).unwrap();
+    fn compare(module_name : &str, max_degree : i32) {
+        let a = Config {
+            module_name : String::from(module_name),
+            max_degree,
+            algebra_name : String::from("adem")
+        };
+        let m = Config {
+            module_name : String::from(module_name),
+            max_degree,
+            algebra_name : String::from("milnor")
+        };
 
-        assert_eq!(run_adem(&contents, max_degree), run_milnor(&contents, max_degree));
+        match (run(a), run(m)) {
+            (Err(e), _)    => panic!("Failed to read file: {}", e),
+            (_, Err(e))    => panic!("Failed to read file: {}", e),
+            (Ok(x), Ok(y)) => assert_eq!(x, y)
+        }
     }
-
-    fn run_adem(contents : &str, max_degree : i32) -> String {
-        let mut json : Value = serde_json::from_str(contents).unwrap();
-        let p = json["p"].as_u64().unwrap() as u32;
-
-        let A = AdemAlgebra::new(p, p != 2, false, max_degree);
-        A.compute_basis(max_degree);
-        let M = FiniteDimensionalModule::from_json(&A, "adem", &mut json);
-        let CC = ChainComplexConcentratedInDegreeZero::new(&M);
-        let res = Resolution::new(&CC, max_degree, None, None);
-        res.resolve_through_degree(max_degree);
-
-        res.graded_dimension_string()
-    }
-
-    fn run_milnor(contents : &str, max_degree : i32) -> String {
-        let mut json : Value = serde_json::from_str(contents).unwrap();
-        let p = json["p"].as_u64().unwrap() as u32;
-
-        let A = MilnorAlgebra::new(p);
-        A.compute_basis(max_degree);
-        let M = FiniteDimensionalModule::from_json(&A, "milnor", &mut json);
-        let CC = ChainComplexConcentratedInDegreeZero::new(&M);
-        let res = Resolution::new(&CC, max_degree, None, None);
-        res.resolve_through_degree(max_degree);
-
-        res.graded_dimension_string()
-    }
-
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,7 @@ impl Config {
         }
         let module_name = args[1].clone();
         let max_deg_result : Result<i32,_> = args[2].parse();
-        
+
         if let Err(error) = max_deg_result {
             return Err(format!("{} in argument max_degree.", error));
         }

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -614,7 +614,7 @@ mod tests {
             for (i,x) in input.iter().enumerate(){
                 m[i].pack(x);
             }
-            let mut output_pivots_cvec = [-1; cols];
+            let mut output_pivots_cvec = vec![-1; cols];
             m.row_reduce(&mut output_pivots_cvec);
             let mut unpacked_row : Vec<u32> = vec![0; cols];
             for (i,x) in input.iter().enumerate(){

--- a/src/milnor_algebra.rs
+++ b/src/milnor_algebra.rs
@@ -177,7 +177,6 @@ impl Algebra for MilnorAlgebra {
         let mut q_part = 0;
         let mut degree = 0;
 
-        println!("{:?}", json);
         if self.profile.generic {
             let p_list = json[1].as_array().unwrap();
             let q_list = json[0].as_array().unwrap();
@@ -201,7 +200,6 @@ impl Algebra for MilnorAlgebra {
                 let val = p_list[i].as_u64().unwrap();
                 p_part.push(val as u32);
                 degree += (val as i32) * xi_degrees[i];
-                println!("{:?}", p_part);
             }
         }
         let m = MilnorBasisElement { p_part, q_part, degree };

--- a/src/milnor_algebra.rs
+++ b/src/milnor_algebra.rs
@@ -229,7 +229,7 @@ impl MilnorAlgebra {
 
         let xi_degrees = crate::combinatorics::get_xi_degrees(self.p);
 
-        for d in (old_deg + 1) ..= new_deg + 1 {
+        for d in (old_deg + 1) ..= new_deg {
             let mut new_row = Vec::new(); // Improve this
 
             for i in 0..xi_degrees.len() {

--- a/src/milnor_algebra.rs
+++ b/src/milnor_algebra.rs
@@ -302,7 +302,7 @@ impl MilnorAlgebra {
                 residue += q;
             }
             self.qpart_table[residue as usize].push(QPart {
-                degree : total, 
+                degree : total,
                 q_part : bit_string
             });
         }
@@ -534,7 +534,7 @@ impl<'a> Iterator for PPartMultiplier<'a> {
             let i_min = if diag_idx + 1 > self.cols { diag_idx + 1 - self.cols } else {0} ;
             let i_max = std::cmp::min(1 + diag_idx, self.rows);
             let mut sum = 0;
-            
+
             diagonal.clear();
 
             for i in i_min..i_max {

--- a/src/milnor_algebra.rs
+++ b/src/milnor_algebra.rs
@@ -85,7 +85,7 @@ impl std::fmt::Display for MilnorBasisElement {
 pub struct MilnorAlgebra {
     pub profile : MilnorProfile,
     name : String,
-    max_degree : Mutex<i32>,
+    next_degree : Mutex<i32>,
     p : u32,
     ppart_table : OnceVec<Vec<PPart>>,
     qpart_table : Vec<OnceVec<QPart>>,
@@ -110,7 +110,7 @@ impl MilnorAlgebra {
             p,
             profile: profile,
             name : format!("MilnorAlgebra(p={})", p),
-            max_degree : Mutex::new(-1),
+            next_degree : Mutex::new(0),
             ppart_table : OnceVec::new(),
             qpart_table,
             basis_table : OnceVec::new(),
@@ -124,33 +124,33 @@ impl Algebra for MilnorAlgebra {
         self.p
     }
 
-    fn get_max_degree(&self) -> i32 {
-        self.basis_table.len() as i32
-    }
-
     fn get_name(&self) -> &str {
         &self.name
     }
 
     fn get_filtration_one_products(&self) -> Vec<(&str, i32, usize)> {Vec::new()} // Implement this
 
-    fn compute_basis(&self, degree : i32) {
-        let mut old_max_degree = self.max_degree.lock().unwrap();
+    fn compute_basis(&self, max_degree : i32) {
+        let mut next_degree = self.next_degree.lock().unwrap();
 
-        self.compute_ppart(degree, *old_max_degree);
-        self.compute_qpart(degree, *old_max_degree);
+        if max_degree < *next_degree {
+            return;
+        }
 
-        self.basis_table.reserve((degree - *old_max_degree) as usize);
-        self.basis_element_to_index_map.reserve((degree - *old_max_degree) as usize);
+        self.compute_ppart(*next_degree, max_degree);
+        self.compute_qpart(*next_degree, max_degree);
+
+        self.basis_table.reserve((max_degree - *next_degree + 1) as usize);
+        self.basis_element_to_index_map.reserve((max_degree - *next_degree + 1) as usize);
 
         if self.profile.generic {
-            self.generate_basis_generic(degree, *old_max_degree);
+            self.generate_basis_generic(*next_degree, max_degree);
         } else {
-            self.generate_basis_2(degree, *old_max_degree);
+            self.generate_basis_2(*next_degree, max_degree);
         }
 
         // Populate hash map
-        for d in (*old_max_degree + 1) as usize..(degree + 1) as usize {
+        for d in *next_degree as usize ..= max_degree as usize {
             let basis = &self.basis_table[d];
             let mut map = HashMap::with_capacity(basis.len());
             for i in 0 .. basis.len() {
@@ -158,7 +158,7 @@ impl Algebra for MilnorAlgebra {
             }
             self.basis_element_to_index_map.push(map);
         }
-        *old_max_degree = degree;
+        *next_degree = max_degree + 1;
     }
 
     fn get_dimension(&self, degree : i32, excess : i32) -> usize {
@@ -215,23 +215,23 @@ impl Algebra for MilnorAlgebra {
 
 // Compute basis functions
 impl MilnorAlgebra {
-    fn compute_ppart(&self, degree : i32, old_max_degree : i32) {
-        let mut old_max_degree = old_max_degree;
-        if old_max_degree == -1 {
+    fn compute_ppart(&self, next_degree : i32, max_degree : i32) {
+        let mut next_degree = next_degree;
+        if next_degree == 0 {
             self.ppart_table.push(vec![Vec::new()]);
-            old_max_degree = 0;
+            next_degree = 1;
         }
 
         let p = self.p as i32;
         let q = if p == 2 {1} else {2 * p - 2};
-        let new_deg = degree/q;
-        let old_deg = old_max_degree/q;
+        let new_deg = max_degree/q;
+        let old_deg = (next_degree-1)/q;
 
         self.ppart_table.reserve((new_deg - old_deg) as usize);
 
         let xi_degrees = crate::combinatorics::get_xi_degrees(self.p);
 
-        for d in (old_deg + 1)..(new_deg + 1) {
+        for d in (old_deg + 1) ..= new_deg + 1 {
             let mut new_row = Vec::new(); // Improve this
 
             for i in 0..xi_degrees.len() {
@@ -261,22 +261,22 @@ impl MilnorAlgebra {
         }
     }
 
-    fn compute_qpart(&self, new_max_degree : i32, old_max_degree : i32) {
+    fn compute_qpart(&self, next_degree : i32, max_degree : i32) {
         let q = (2 * self.p - 2) as i32;
 
         if !self.profile.generic {
             return;
         }
 
-        let mut old_max_degree = old_max_degree;
-        if old_max_degree == -1 {
+        let mut next_degree = next_degree;
+        if next_degree == 0 {
             self.qpart_table[0].push( ZERO_QPART.clone());
-            old_max_degree = 0;
+            next_degree = 1;
         }
 
         let tau_degrees = crate::combinatorics::get_tau_degrees(self.p);
-        let old_max_tau = tau_degrees.iter().position(|d| *d > old_max_degree).unwrap(); // Use expect instead
-        let new_max_tau = tau_degrees.iter().position(|d| *d > new_max_degree).unwrap();
+        let old_max_tau = tau_degrees.iter().position(|d| *d > next_degree - 1).unwrap(); // Use expect instead
+        let new_max_tau = tau_degrees.iter().position(|d| *d > max_degree).unwrap();
 
         let bit_string_min : u32 = 1 << old_max_tau;
         let bit_string_max : u32 = 1 << new_max_tau;
@@ -308,10 +308,10 @@ impl MilnorAlgebra {
         }
     }
 
-    fn generate_basis_generic(&self, degree : i32, old_max_degree : i32) {
+    fn generate_basis_generic(&self, next_degree : i32, max_degree : i32) {
         let q = (2 * self.p - 2) as usize;
 
-        for d in (old_max_degree + 1) as usize..(degree + 1) as usize {
+        for d in next_degree as usize..= max_degree as usize {
             let mut new_table = Vec::new(); // Initialize size
 
             for q_part in self.qpart_table[d % q].iter() {
@@ -330,8 +330,8 @@ impl MilnorAlgebra {
         }
     }
 
-    fn generate_basis_2(&self, degree:i32, old_max_degree : i32) {
-        for i in ((old_max_degree + 1) as usize)..((degree + 1) as usize) {
+    fn generate_basis_2(&self, next_degree : i32, max_degree : i32) {
+        for i in next_degree as usize ..= max_degree as usize {
             self.basis_table.push(
                 self.ppart_table[i]
                 .iter()


### PR DESCRIPTION
Removed `get_max_degree` from the Algebra trait.

In `MilnorAlgebra`, it makes a bit more sense to remember the next degree
to compute instead of the previous max degree. This lets us write
```
for n in next_degree ..= max_degree
```
instead of awkward +1's.

I tried to modify `AdemAlgebra` to follow the same pattern, but got confused by how generate_multiplication_table works. Might try again later, or feel free to do it yourself.