### PR TITLE
DO NOT MERGE Concurrency proof of concept

### DIFF
--- a/src/finite_dimensional_module.rs
+++ b/src/finite_dimensional_module.rs
@@ -3,11 +3,11 @@ use crate::algebra::Algebra;
 use crate::module::{Module, OptionModule};
 use serde_json::value::Value;
 use std::collections::HashMap;
-use std::rc::Rc;
+use std::sync::Arc;
 
 
-pub struct FiniteDimensionalModule {
-    algebra : Rc<dyn Algebra>,
+pub struct FiniteDimensionalModule<A : Algebra> {
+    algebra : Arc<A>,
     name : String,
     min_degree : i32,
     max_basis_degree : i32,
@@ -16,13 +16,13 @@ pub struct FiniteDimensionalModule {
     actions : Vec<Vec<Vec<Vec<FpVector>>>>,
 }
 
-impl Module for FiniteDimensionalModule {
+impl<A : Algebra> Module<A> for FiniteDimensionalModule<A> {
     fn get_name(&self) -> &str {
         &self.name
     }
 
-    fn get_algebra(&self) -> Rc<dyn Algebra> {
-        Rc::clone(&self.algebra)
+    fn get_algebra(&self) -> Arc<A> {
+        Arc::clone(&self.algebra)
     }
 
     fn get_min_degree(&self) -> i32 {
@@ -58,8 +58,8 @@ impl Module for FiniteDimensionalModule {
     }
 }
 
-impl FiniteDimensionalModule {
-    pub fn new(algebra : Rc<dyn Algebra>, name : String, min_degree : i32, max_basis_degree : i32, graded_dimension : Vec<usize>) -> Self {
+impl<A : Algebra> FiniteDimensionalModule<A> {
+    pub fn new(algebra : Arc<A>, name : String, min_degree : i32, max_basis_degree : i32, graded_dimension : Vec<usize>) -> Self {
         algebra.compute_basis(max_basis_degree);
         assert!(max_basis_degree >= min_degree);
         let actions = FiniteDimensionalModule::allocate_actions(&algebra, min_degree, (max_basis_degree - min_degree) as usize, &graded_dimension);
@@ -73,13 +73,13 @@ impl FiniteDimensionalModule {
         }
     }
 
-    pub fn from_json(algebra : Rc<dyn Algebra>, algebra_name: &str, json : &mut Value) -> Self {
+    pub fn from_json(algebra : Arc<A>, algebra_name: &str, json : &mut Value) -> Self {
         let gens = json["gens"].take();
         let (min_degree, graded_dimension, gen_to_idx) = Self::module_gens_from_json(&gens);
         let name = json["name"].as_str().unwrap().to_string();
         let mut actions_value = json[algebra_name.to_owned() + "_actions"].take();
         let actions = actions_value.as_array_mut().unwrap();
-        let mut result = Self::new(Rc::clone(&algebra), name, min_degree, min_degree + graded_dimension.len() as i32, graded_dimension);
+        let mut result = Self::new(Arc::clone(&algebra), name, min_degree, min_degree + graded_dimension.len() as i32, graded_dimension);
         for action in actions.iter_mut() {
             let op = action["op"].take();
             let (degree, idx) = algebra.json_to_basis(op);
@@ -123,7 +123,7 @@ impl FiniteDimensionalModule {
         return (min_degree as i32, graded_dimension, gen_to_idx);
     }
 
-    fn allocate_actions(algebra : &Rc<dyn Algebra>, min_degree : i32, basis_degree_range : usize, graded_dimension : &Vec<usize>) -> Vec<Vec<Vec<Vec<FpVector>>>> {
+    fn allocate_actions(algebra : &Arc<A>, min_degree : i32, basis_degree_range : usize, graded_dimension : &Vec<usize>) -> Vec<Vec<Vec<Vec<FpVector>>>> {
         let mut result : Vec<Vec<Vec<Vec<FpVector>>>> = Vec::with_capacity(basis_degree_range);
         // Count number of triples (x, y, op) with |x| + |op| = |y|.
         // The amount of memory we need to allocate is:
@@ -200,7 +200,7 @@ impl FiniteDimensionalModule {
         // (in_deg) -> (out_deg) -> (op_index) -> (in_index) -> Vector
         let output_vector = &mut self.actions[input_degree_idx][in_out_diff][operation_idx][input_idx];
         output_vector.pack(&output);
-    }    
+    }
 
     fn get_action(
         &self,
@@ -229,4 +229,4 @@ impl FiniteDimensionalModule {
     }    
 }
 
-pub type OptionFDModule = OptionModule<FiniteDimensionalModule>;
+pub type OptionFDModule<A> = OptionModule<A, FiniteDimensionalModule<A>>;

--- a/src/free_module.rs
+++ b/src/free_module.rs
@@ -3,7 +3,7 @@ use crate::once::OnceVec;
 use crate::fp_vector::{FpVector, FpVectorT};
 use crate::algebra::Algebra;
 use crate::module::Module;
-use std::rc::Rc;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct OperationGeneratorPair {
@@ -19,21 +19,21 @@ pub struct FreeModuleTableEntry {
     pub generator_to_index : Vec<Vec<usize>>,
 }
 
-pub struct FreeModule {
-    pub algebra : Rc<dyn Algebra>,
+pub struct FreeModule<A : Algebra> {
+    pub algebra : Arc<A>,
     pub name : String,
     pub min_degree : i32,
     pub max_degree : Mutex<i32>,
     pub table : OnceVec<FreeModuleTableEntry>
 }
 
-impl Module for FreeModule {
+impl<A : Algebra> Module<A> for FreeModule<A> {
     fn get_name(&self) -> &str {
         &self.name
     }
 
-    fn get_algebra(&self) -> Rc<dyn Algebra> {
-        Rc::clone(&self.algebra)
+    fn get_algebra(&self) -> Arc<A> {
+        Arc::clone(&self.algebra)
     }
 
     fn get_min_degree(&self) -> i32 {
@@ -82,8 +82,8 @@ impl Module for FreeModule {
     }
 }
 
-impl FreeModule {
-    pub fn new(algebra : Rc<dyn Algebra>, name : String, min_degree : i32) -> Self {
+impl<A : Algebra> FreeModule<A> {
+    pub fn new(algebra : Arc<A>, name : String, min_degree : i32) -> Self {
         Self {
             algebra,
             name,
@@ -206,9 +206,9 @@ mod tests {
     #[test]
     fn test_free_mod(){
         let p = 2;
-        let A = Rc::new(AdemAlgebra::new(p, p != 2, false));
+        let A = Arc::new(AdemAlgebra::new(p, p != 2, false));
         A.compute_basis(10);
-        let M = FreeModule::new(Rc::clone(&A) as Rc<dyn Algebra>, "".to_string(), 0);
+        let M = FreeModule::new(Arc::clone(&A), "".to_string(), 0);
         let (lock, table) = M.construct_table(0);
         M.add_generators(0, lock, table, 1);
         let (lock, table) = M.construct_table(1);

--- a/src/free_module_homomorphism.rs
+++ b/src/free_module_homomorphism.rs
@@ -1,16 +1,17 @@
 use std::sync::{Mutex, MutexGuard};
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::once::OnceVec;
 use crate::fp_vector::{FpVector, FpVectorT};
 use crate::matrix::{Matrix, Subspace, QuasiInverse};
 use crate::module::Module;
+use crate::algebra::Algebra;
 use crate::module_homomorphism::ModuleHomomorphism;
 use crate::free_module::{FreeModule, FreeModuleTableEntry};
 
-pub struct FreeModuleHomomorphism<M : Module> {
-    pub source : Rc<FreeModule>,
-    pub target : Rc<M>,
+pub struct FreeModuleHomomorphism<A : Algebra, M : Module<A>> {
+    pub source : Arc<FreeModule<A>>,
+    pub target : Arc<M>,
     outputs : OnceVec<Vec<FpVector>>, // degree --> input_idx --> output
     kernel : OnceVec<Subspace>,
     quasi_inverse : OnceVec<QuasiInverse>,
@@ -19,13 +20,13 @@ pub struct FreeModuleHomomorphism<M : Module> {
     degree_shift : i32
 }
 
-impl<M : Module> ModuleHomomorphism<FreeModule, M> for FreeModuleHomomorphism<M> {
-    fn get_source(&self) -> Rc<FreeModule> {
-        Rc::clone(&self.source)
+impl<A : Algebra, M : Module<A>> ModuleHomomorphism<A, FreeModule<A>, M> for FreeModuleHomomorphism<A, M> {
+    fn get_source(&self) -> Arc<FreeModule<A>> {
+        Arc::clone(&self.source)
     }
 
-    fn get_target(&self) -> Rc<M> {
-        Rc::clone(&self.target)
+    fn get_target(&self) -> Arc<M> {
+        Arc::clone(&self.target)
     }
 
     fn apply_to_basis_element(&self, result : &mut FpVector, coeff : u32, input_degree : i32, input_index : usize){
@@ -73,8 +74,8 @@ impl<M : Module> ModuleHomomorphism<FreeModule, M> for FreeModuleHomomorphism<M>
 // }
 
 
-impl<M : Module> FreeModuleHomomorphism<M> {
-    pub fn new(source : Rc<FreeModule>, target : Rc<M>, min_degree : i32, degree_shift : i32, max_degree : i32) -> Self {
+impl<A : Algebra, M : Module<A>> FreeModuleHomomorphism<A, M> {
+    pub fn new(source : Arc<FreeModule<A>>, target : Arc<M>, min_degree : i32, degree_shift : i32, max_degree : i32) -> Self {
         let num_degrees = max_degree as usize - min_degree as usize;
         let outputs = OnceVec::with_capacity(num_degrees);
         let kernel = OnceVec::with_capacity(num_degrees);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ mod free_module;
 mod free_module_homomorphism;
 mod chain_complex;
 mod resolution;
-mod wasm_bindings;
+//mod wasm_bindings;
 
 #[cfg(test)]
 extern crate rand;
@@ -26,7 +26,7 @@ extern crate enum_dispatch;
 
 extern crate serde_json;
 
-extern crate wasm_bindgen;
+//extern crate wasm_bindgen;
 extern crate web_sys;
 
 use crate::algebra::Algebra;
@@ -38,7 +38,7 @@ use crate::module_homomorphism::{ZeroHomomorphism}; //ModuleHomomorphism
 use crate::chain_complex::{ChainComplexConcentratedInDegreeZero as CCDZ}; // ChainComplex,
 use crate::resolution::Resolution;
 
-use std::rc::Rc;
+use std::sync::Arc;
 use std::error::Error;
 use serde_json::value::Value;
 
@@ -59,32 +59,34 @@ impl Error for InvalidAlgebraError {
     }
 }
 
-pub struct AlgebraicObjectsBundle {
-    algebra : Rc<dyn Algebra>,
-    module : Option<Rc<FDModule>>,
-    chain_complex : Rc<CCDZ<FDModule>>,
+pub struct AlgebraicObjectsBundle<A : Algebra> {
+    algebra : Arc<A>,
+    module : Option<Arc<FDModule<A>>>,
+    chain_complex : Arc<CCDZ<A, FDModule<A>>>,
     resolution : Box<Resolution<
-                    OptionFDModule, 
-                    ZeroHomomorphism<OptionFDModule, OptionFDModule>,
-                    CCDZ<FDModule>
+                    A,
+                    OptionFDModule<A>,
+                    ZeroHomomorphism<A, OptionFDModule<A>, OptionFDModule<A>>,
+                    CCDZ<A, FDModule<A>>
                 >>
 }
 
-pub fn construct(config : &Config) -> Result<AlgebraicObjectsBundle, Box<dyn Error>> {
+pub fn construct(config : &Config) -> Result<AlgebraicObjectsBundle<MilnorAlgebra>, Box<dyn Error>> {
     let contents = std::fs::read_to_string(format!("static/modules/{}.json", config.module_name))?;
     let mut json : Value = serde_json::from_str(&contents)?;
     let p = json["p"].as_u64().unwrap() as u32;
 
     // You need a box in order to allow for different possible types implementing the same trait
-    let algebra : Rc<dyn Algebra>;
-    match config.algebra_name.as_ref() {
-        "adem" => algebra = Rc::new(AdemAlgebra::new(p, p != 2, false)),
-        "milnor" => algebra = Rc::new(MilnorAlgebra::new(p)),
-        _ => { return Err(Box::new(InvalidAlgebraError { name : config.algebra_name.clone() })); }
-    };
-    let module : Rc<FDModule> = Rc::new(FDModule::from_json(Rc::clone(&algebra), &config.algebra_name, &mut json));
-    let cc : Rc<CCDZ<FDModule>> = Rc::new(CCDZ::new(Rc::clone(&module)));
-    let res = Box::new(Resolution::new(Rc::clone(&cc), config.max_degree, None, None));
+//    let algebra : Arc<dyn Algebra>;
+    let algebra = Arc::new(MilnorAlgebra::new(p));
+//    match config.algebra_name.as_ref() {
+//        "adem" => algebra = Arc::new(AdemAlgebra::new(p, p != 2, false)),
+//        "milnor" => algebra = Arc::new(MilnorAlgebra::new(p)),
+//        _ => { return Err(Box::new(InvalidAlgebraError { name : config.algebra_name.clone() })); }
+//    };
+    let module = Arc::new(FDModule::from_json(Arc::clone(&algebra), &config.algebra_name, &mut json));
+    let cc = Arc::new(CCDZ::new(Arc::clone(&module)));
+    let res = Box::new(Resolution::new(Arc::clone(&cc), config.max_degree, None, None));
 
     Ok(AlgebraicObjectsBundle {
         algebra,
@@ -92,6 +94,14 @@ pub fn construct(config : &Config) -> Result<AlgebraicObjectsBundle, Box<dyn Err
         chain_complex: cc,
         resolution: res
     })
+}
+
+pub fn run_threaded(config : &Config) -> Result<String, Box<dyn Error>> {
+    let bundle = construct(&config)?;
+    let res = Arc::new(*bundle.resolution);
+
+    Arc::clone(&res).resolve_through_degree_threaded(config.max_degree);
+    Ok(res.graded_dimension_string())
 }
 
 pub fn run(config : &Config) -> Result<String, Box<dyn Error>> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ extern crate rust_ext;
 
 use rust_ext::Config;
 use rust_ext::run;
+use rust_ext::run_threaded;
 
 const BOLD_ANSI_CODE : &str = "\x1b[1m";
 
@@ -13,7 +14,7 @@ fn main() {
         std::process::exit(1);
     });
 
-    match run(&config) {
+    match run_threaded(&config) {
         Ok(string) => println!("{}{}", BOLD_ANSI_CODE, string),
         Err(e) => { eprintln!("Application error: {}", e); std::process::exit(1); }
     }

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -490,7 +490,7 @@ impl Matrix {
         let mut block_rows : Vec<usize> = Vec::with_capacity(target_blocks.len());
         let mut last_block = 0;
         loop {
-            // Start searching for the end of the last block.
+            // Start seasynching for the end of the last block.
             // The end of the last block happens in the first row that has a pivot in a column to the right of it.
             // So look through columns to the right of the last block until we locate a pivot.
             for i in target_blocks[last_block] .. columns + 1 {

--- a/src/module.rs
+++ b/src/module.rs
@@ -1,4 +1,4 @@
-use std::rc::Rc;
+use std::sync::Arc;
 // use enum_dispatch::enum_dispatch;
 
 use crate::fp_vector::{FpVector, FpVectorT};
@@ -8,11 +8,11 @@ use crate::algebra::Algebra;
 
 // }
 
-pub trait Module {
+pub trait Module<A : Algebra> {
     fn get_prime(&self) -> u32 {
         self.get_algebra().get_prime()
     }
-    fn get_algebra(&self) -> Rc<dyn Algebra>;
+    fn get_algebra(&self) -> Arc<A>;
     fn get_name(&self) -> &str;
     // fn get_type() -> Module_Type;
     // int min_degree;
@@ -63,13 +63,13 @@ pub trait Module {
     } 
 }
 
-pub struct ZeroModule {
-    algebra : Rc<dyn Algebra>,
+pub struct ZeroModule<A : Algebra> {
+    algebra : Arc<A>,
     name : String
 }
 
-impl ZeroModule {
-    pub fn new(algebra : Rc<dyn Algebra>) -> Self {
+impl<A : Algebra> ZeroModule<A> {
+    pub fn new(algebra : Arc<A>) -> Self {
         let name = format!("Zero Module over {}", algebra.get_name());
         ZeroModule {
             algebra,
@@ -78,9 +78,9 @@ impl ZeroModule {
     }
 }
 
-impl Module for ZeroModule {
-    fn get_algebra(&self) -> Rc<dyn Algebra> {
-        Rc::clone(&self.algebra)
+impl<A : Algebra> Module<A> for ZeroModule<A> {
+    fn get_algebra(&self) -> Arc<A> {
+        Arc::clone(&self.algebra)
     }
     
     fn get_name(&self) -> &str{
@@ -113,7 +113,7 @@ impl Module for ZeroModule {
 // }
 
 // impl<L : Module, R : Module> Module for ModuleChoice<L, R> {
-//     fn get_algebra(&self) -> Rc<dyn Algebra> {
+//     fn get_algebra(&self) -> Arc<dyn Algebra> {
 //         match self {
 //             ModuleChoice::IntroL(l) => l.get_algebra(),
 //             ModuleChoice::IntroR(r) => r.get_algebra()
@@ -164,13 +164,13 @@ impl Module for ZeroModule {
 // }
 
 
-pub enum OptionModule<M : Module> {
-    Some(Rc<M>),
-    Zero(Rc<ZeroModule>)
+pub enum OptionModule<A : Algebra, M : Module<A>> {
+    Some(Arc<M>),
+    Zero(Arc<ZeroModule<A>>)
 }
 
-impl<M : Module> Module for OptionModule<M> {
-    fn get_algebra(&self) -> Rc<dyn Algebra> {
+impl<A : Algebra, M : Module<A>> Module<A> for OptionModule<A, M> {
+    fn get_algebra(&self) -> Arc<A> {
         match self {
             OptionModule::Some(l) => l.get_algebra(),
             OptionModule::Zero(r) => r.get_algebra()

--- a/src/once.rs
+++ b/src/once.rs
@@ -61,3 +61,6 @@ impl<T> Index<usize> for OnceVec<T> {
         self.get(key)
     }
 }
+
+unsafe impl<T> Send for OnceVec<T> { }
+unsafe impl<T> Sync for OnceVec<T> { }


### PR DESCRIPTION
There are various reasons why you shouldn't merge this. For one, the code is pretty bad, and `wasm_bindgen` is currently broken. Another is that it is actually slower than the unthreaded version.

Here are the difficulties one encounters when trying to implement concurrency:
- You need to require everything to be `Send + Sync` in your generic type parameters. In particular, this requires making the Algebra parameter explicit, which leads to problems in `lib.construct`. We can avoid this by replacing `dyn Algebra` with `dyn Algebra + Send + Sync` everywhere, but I don't think that is good practice either. The most annoying part of this problem is the `add_class` and `add_structline` functions you pass. I didn't quite solve this, which is why `wasm_bindings` is broken.
 - I was worried about possible data races where one of the threads updates a value but the previous value is cached in the other thread and not updated. I don't know if this is a thing that can actually happen, but it doesn't appear to happen to me. Again, I don't understand concurrency.

I would recommend something like a complete rewrite for the actual version that gets implemented.