### PR TITLE
Simplify resolution.rs a bit

### DIFF
--- a/src/chain_complex.rs
+++ b/src/chain_complex.rs
@@ -1,4 +1,3 @@
-use crate::matrix::{ Subspace }; //QuasiInverse
 use crate::algebra::Algebra;
 use crate::module::{Module, ZeroModule, OptionModule};
 use crate::module_homomorphism::{ModuleHomomorphism, ZeroHomomorphism};
@@ -14,25 +13,6 @@ pub trait ChainComplex<M : Module, F : ModuleHomomorphism<M, M>> {
     fn get_module(&self, homological_degree : u32) -> Rc<M>;
     fn get_differential(&self, homological_degree : u32) -> &F;
     fn compute_through_bidegree(&self, homological_degree : u32, degree : i32);
-    // fn computed_through_bidegree_q(&self, homological_degree : u32, degree : i32) -> bool { true }
-
-    fn compute_kernel_and_image(&self,  homological_degree : u32, degree : i32){
-        let p = self.get_prime();
-        let d = self.get_differential(homological_degree);
-        if d.get_max_kernel_degree() >= degree {
-            return;
-        }
-        let mut lock = d.get_lock();
-        if homological_degree == 0 {
-            let module = self.get_module(0);
-            let dim = module.get_dimension(degree);
-            let kernel = Subspace::entire_space(p, dim);
-            d.set_kernel(&lock, degree, kernel);
-            *lock += 1;
-            return;
-        }
-        d.compute_kernel_and_image(&mut lock, degree);
-    }
 }
 
 

--- a/src/finitely_presented_module.rs
+++ b/src/finitely_presented_module.rs
@@ -99,7 +99,7 @@ impl Module for FinitelyPresentedModule {
         let min_degree = self.get_min_degree();
         for i in self.index_table.len() as i32 + min_degree ..= degree {
             let mut lock = self.map.get_lock();
-            self.map.compute_kernel_and_image(&mut lock, i);
+            self.map.compute_quasi_inverse(&mut lock, i);
             let qi = self.map.get_quasi_inverse(degree).unwrap();
             let image = qi.image.as_ref().unwrap();
             let mut gen_idx_to_fp_idx = Vec::new();

--- a/src/free_module_homomorphism.rs
+++ b/src/free_module_homomorphism.rs
@@ -43,19 +43,6 @@ impl<M : Module> ModuleHomomorphism<FreeModule, M> for FreeModuleHomomorphism<M>
         self.max_degree.lock().unwrap()
     }
 
-    fn set_kernel(&self, lock : &MutexGuard<i32>, degree : i32, kernel : Subspace){
-        assert!(degree >= self.min_degree);
-        let degree_idx = (degree - self.min_degree) as usize;
-        assert_eq!(degree_idx, self.kernel.len());
-        self.kernel.push(kernel);
-    }
-
-    fn get_kernel(&self, degree : i32) -> Option<&Subspace> {
-        assert!(degree >= self.min_degree);
-        let degree_idx = (degree - self.min_degree) as usize;
-        Some(&self.kernel[degree_idx])
-    }
-
     fn set_quasi_inverse(&self, lock : &MutexGuard<i32>, degree : i32, quasi_inverse : QuasiInverse){
         assert!(degree >= self.min_degree);
         let degree_idx = (degree - self.min_degree) as usize;

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -611,10 +611,10 @@ impl Matrix {
         return added_pivots;
     }
 
-    pub fn extend_image_to_desired_image(&mut self, 
+    fn extend_image_to_desired_image(&mut self,
         mut first_empty_row : usize,
         start_column : usize, end_column : usize,
-        current_pivots : &Vec<isize>, desired_image : &Subspace
+        current_pivots : &Vec<isize>, desired_image : Subspace
     ) -> Vec<usize> {
         // println!("Extend_image : cur_pivs : {:?}, desired_image : {:?}", current_pivots, desired_image);
         let mut added_pivots = Vec::new();
@@ -650,7 +650,7 @@ impl Matrix {
     pub fn extend_image(&mut self, 
         first_empty_row : usize, 
         start_column : usize, end_column : usize, 
-        current_pivots : &Vec<isize>, desired_image : Option<&Subspace>
+        current_pivots : &Vec<isize>, desired_image : Option<Subspace>
     ) -> Vec<usize> {
         if let Some(image) = desired_image {
             return self.extend_image_to_desired_image(first_empty_row, start_column, end_column, current_pivots, image);

--- a/src/module_homomorphism.rs
+++ b/src/module_homomorphism.rs
@@ -22,8 +22,6 @@ pub trait ModuleHomomorphism<S : Module, T : Module> {
     fn get_lock(&self) -> MutexGuard<i32>;
 
     fn get_max_kernel_degree(&self) -> i32;
-    fn set_kernel(&self, lock : &MutexGuard<i32>, degree : i32, kernel : Subspace);
-    fn get_kernel(&self, degree : i32) -> Option<&Subspace>;
 
     fn set_quasi_inverse(&self, lock : &MutexGuard<i32>, degree : i32, kernel : QuasiInverse);    
     fn get_quasi_inverse(&self, degree : i32) -> Option<&QuasiInverse>;
@@ -33,7 +31,7 @@ pub trait ModuleHomomorphism<S : Module, T : Module> {
         return option_quasi_inverse.and_then(|quasi_inverse| quasi_inverse.image.as_ref() );
     }
 
-    fn compute_kernel_and_image(&self, lock : &mut MutexGuard<i32>, degree : i32){
+    fn compute_quasi_inverse(&self, lock : &mut MutexGuard<i32>, degree : i32){
         let p = self.get_prime();
         let source_dimension = self.get_source().get_dimension(degree);
         let target_dimension = self.get_target().get_dimension(degree);
@@ -46,10 +44,6 @@ pub trait ModuleHomomorphism<S : Module, T : Module> {
         }
         let mut pivots = vec![-1;columns];
         matrix.row_reduce(&mut pivots);
-        let kernel = matrix.compute_kernel(&pivots, padded_target_dimension);
-        let kernel_rows = kernel.matrix.get_rows();
-        self.set_kernel(&lock, degree, kernel);        
-        let image_rows = matrix.get_rows() - kernel_rows;
         let quasi_inverse = matrix.compute_quasi_inverse(&pivots, target_dimension, padded_target_dimension);
         self.set_quasi_inverse(&lock, degree, quasi_inverse);
     }
@@ -114,8 +108,6 @@ impl<S : Module, T : Module> ModuleHomomorphism<S, T> for ZeroHomomorphism<S, T>
     }
 
     fn get_max_kernel_degree(&self) -> i32 { 1000000 }
-    fn set_kernel(&self, lock : &MutexGuard<i32>, degree : i32, kernel : Subspace){}
-    fn get_kernel(&self, degree : i32) -> Option<&Subspace> { None }
 
     fn set_quasi_inverse(&self, lock : &MutexGuard<i32>, degree : i32, kernel : QuasiInverse){}    
     fn get_quasi_inverse(&self, degree : i32) -> Option<&QuasiInverse>{ None }


### PR DESCRIPTION
The general idea of this pull request is to simplify what is going on in `resolution::step`, and in particular minimize the amount of data it needs. Ultimately the goal is that when we make this concurrent, we do not have to pass all of `self` to the threads, which is possibly slow and also requires us to label everything as Sync + Send.

In particular, the code I removed here is `set_kernel` and `get_kernel`, which is only used exactly once throughout the code, and in the particular case where it is used, it is not even actually set to the kernel of the homomorphism. I also removed `compute_kernel_and_image` which isn't used (apologies if you intend to use it for further applications). There is one particular instance where it is used but that is only to get the quasi-inverse, so I renamed that function to a more suitable name.

I also tried to document the `generate_old_kernel_and_compute_new_kernel` code a bit but was confused near the end. Help would be welcome (see comments for details).

Nevertheless, for the purposes of concurrency, it seems unavoidable that we have to pass the `Algebra` objects over, which would still require marking them as `Sync + Send`.