### PR TITLE
A pretty awful AJAX server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ opt-level = 3
 debug = true
 
 [workspace]
-members = ["wasm-bindgen-noop"]
+members = ["wasm-bindgen-noop", "ext_ajax"]
 
 # The `web-sys` crate allows you to interact with the various browser APIs,
 # like the DOM.

--- a/ext_ajax/.gitignore
+++ b/ext_ajax/.gitignore
@@ -1,0 +1,1 @@
+interface/bundle.js

--- a/ext_ajax/Cargo.toml
+++ b/ext_ajax/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "ext_ajax"
+version = "0.1.0"
+authors = ["Hood Chatham <hood@mit.edu>", "Dexter Chua <dexter@math.harvard.edu>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+rust_ext = { path = ".." }

--- a/ext_ajax/README.md
+++ b/ext_ajax/README.md
@@ -1,0 +1,7 @@
+This uses server-sent events to calculate Ext with the Rust binary and then displaying it on a browser.
+
+To run the web server, first copy `bundle.js` from `js_spectralsequences` to `interfaces/`. Then run
+```
+$ cargo run --release
+```
+Then navigate to `http://localhost:8080/` to view the webpage.

--- a/ext_ajax/interface/index.css
+++ b/ext_ajax/interface/index.css
@@ -1,0 +1,54 @@
+html, body {
+    height: 100%;
+    min-height: 100%;
+    overflow: hidden;
+}
+
+#main {
+    height: 100%;
+    min-height: 100%;
+    overflow: hidden;
+    position: relative;
+    display: none;
+}
+
+div.tooltip {
+    text-align: center;
+    padding: 5px;
+    font: 12px sans-serif;
+    background: lightsteelblue;
+    border: 0px;
+    border-radius: 8px;
+    pointer-events: none;
+}
+
+#home {
+    font-family: serif;
+    width: 100%;
+    height: 100%;
+    padding-top: 1rem;
+    overflow: auto;
+}
+
+a.flex-grid {
+    display: block;
+    text-align: center;
+    width: 150px;
+    margin: 10px;
+}
+
+#home > section > div {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: center;
+    max-width: 700px;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+#home h1, #home h2 {
+    text-align: center;
+    margin-top: 2rem;
+    margin-bottom: 0.5rem;
+}

--- a/ext_ajax/interface/index.html
+++ b/ext_ajax/interface/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <title>Steenrod Ext</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.2/dist/katex.min.css" integrity="sha384-yFRtMMDnQtDRO8rLpMIKrtPCD5jdktao2TV19YiZYWMDkUR5GQZR/NOVTdquEx1j" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+    <link rel="stylesheet" href="index.css">
+  </head>
+  <body>
+    <div id="home" style="display: none">
+      <h1>Steenrod Ext calculator</h1>
+      <section>
+        <h2>p = 2</h2>
+        <div>
+          <a href="#" class="flex-grid" data="S_2"> $S_2$ </a>
+          <a href="#" class="flex-grid" data="C2"> $C(2)$ </a>
+          <a href="#" class="flex-grid" data="Ceta"> $C(\eta)$ </a>
+          <a href="#" class="flex-grid" data="Cnu"> $C(\nu)$ </a>
+          <a href="#" class="flex-grid" data="Csigma"> $C(\sigma)$ </a>
+          <a href="#" class="flex-grid" data="C2_eta"> $C(2, \eta)$ </a>
+          <a href="#" class="flex-grid" data="C2_sm_Ceta"> $C(2)\wedge C(\eta)$ </a>
+          <a href="#" class="flex-grid" data="Joker"> Joker </a>
+          <a href="#" class="flex-grid" data="RP4"> $\mathbb{RP}^4$ </a>
+          <a href="#" class="flex-grid" data="A-mod-Sq1-Sq2"> $A/(Sq^1, Sq^2)$ </a>
+          <a href="#" class="flex-grid" data="A-mod-Sq1-Sq2-Sq4"> $A/(Sq^1, Sq^2, Sq^4)$ </a>
+          <!--<a href="#" class="flex-grid" data="ko"> $ko$ </a>
+            <a href="#" class="flex-grid" data="tmf2"> $tmf_{(2)}$ </a>-->
+        </div>
+      </section>
+      <section>
+        <h2>p = 3</h2>
+        <div>
+          <a href="#" class="flex-grid" data="S_3"> $S_3$ </a>
+          <a href="#" class="flex-grid" data="C3"> $C(3)$ </a>
+          <a href="#" class="flex-grid" data="Calpha"> $C(\alpha)$ </a>
+          <a href="#" class="flex-grid" data="X3"> $C(\alpha, \alpha)$ </a>
+        </div>
+      </section>
+    </div>
+    <div id="main"></div>
+    <script src="bundle.js" type="text/javascript"></script>
+    <script src="index.js" type="text/javascript"></script>
+  </body>
+</html> 

--- a/ext_ajax/interface/index.js
+++ b/ext_ajax/interface/index.js
@@ -35,16 +35,6 @@ if (!params.module) {
 
     let eventSource = new EventSource("/request/resolve/" + params.module + "/adem/" + degree);
 
-    let opened = false;
-    eventSource.addEventListener("open", function(e) {
-        // If the connection dropped, let it be.
-        if (!opened) {
-            opened = true;
-        } else {
-            eventSource.close();
-        }
-    });
-
     eventSource.addEventListener("addClass", function(e) {
         let d = JSON.parse(e.data);
         sseq.addClass(d.t - d.s, d.s);

--- a/ext_ajax/interface/index.js
+++ b/ext_ajax/interface/index.js
@@ -1,0 +1,64 @@
+// Read URL to see if module is specified.
+let url = new URL(document.location);
+let params = {};
+for(let [k,v] of url.searchParams.entries()){
+    params[k] = v;
+}
+
+if (!params.module) {
+    console.log("Displaying homepage");
+    console.log(document.querySelector("#home"));
+    document.querySelector("#home").style.removeProperty("display");
+
+    HTMLCollection.prototype.forEach = Array.prototype.forEach;
+    let sections = document.querySelector("#home").getElementsByTagName("section");
+
+    sections.forEach(n => {
+        n.children[1].children.forEach(a => {
+            a.innerHTML = Interface.renderLaTeX(a.innerHTML);
+            a.href = `?module=${a.getAttribute("data")}&degree=50`;
+        });
+    });
+} else {
+    window.display = new EditorDisplay("#main");
+    window.sseq = new Sseq();
+
+    let degree = params.degree ? parseInt(params.degree) : 50;
+    sseq.xRange = [0, degree];
+    sseq.yRange = [0, Math.ceil(degree/3)];
+    sseq.initialxRange = [0, degree];
+    sseq.initialyRange = [0, Math.ceil(degree/3)];
+    sseq.offset_size = 0.1;
+    sseq.class_scale = 0.5;
+
+    display.setSseq(sseq);
+
+    let eventSource = new EventSource("/request/resolve/" + params.module + "/adem/" + degree);
+
+    let opened = false;
+    eventSource.addEventListener("open", function(e) {
+        // If the connection dropped, let it be.
+        if (!opened) {
+            opened = true;
+        } else {
+            eventSource.close();
+        }
+    });
+
+    eventSource.addEventListener("addClass", function(e) {
+        let d = JSON.parse(e.data);
+        sseq.addClass(d.t - d.s, d.s);
+    });
+
+    eventSource.addEventListener("addStructline", function(e) {
+        let d = JSON.parse(e.data);
+        let source = sseq.getClassesInDegree(d.source_t - d.source_s, d.source_s)[d.source_idx];
+        let target = sseq.getClassesInDegree(d.target_t - d.target_s, d.target_s)[d.target_idx];
+
+        sseq.addStructline(source, target, d.name);
+    });
+
+    eventSource.addEventListener("done", function(e) {
+        eventSource.close();
+    });
+}

--- a/ext_ajax/modules
+++ b/ext_ajax/modules
@@ -1,0 +1,1 @@
+../static/modules

--- a/ext_ajax/src/main.rs
+++ b/ext_ajax/src/main.rs
@@ -1,0 +1,106 @@
+use rust_ext;
+use std::net::{TcpStream, TcpListener};
+use std::io::prelude::*;
+use std::sync::{Arc, Mutex};
+use std::error::Error;
+use std::thread;
+use std::fs;
+
+const FILE_LIST : [(&str, &str, &str); 5] = [
+    ("", "index.html", "text/html"),
+    ("index.html", "index.html", "text/html"),
+    ("index.js", "index.js", "text/javascript"),
+    ("index.css", "index.css", "text/css"),
+    ("bundle.js", "bundle.js", "text/javascript")];
+
+
+fn main() {
+    let listener = TcpListener::bind("127.0.0.1:8080").unwrap();
+
+    for stream in listener.incoming() {
+        let stream = stream.unwrap();
+
+        match handle_connection(stream) {
+            Ok(_) => (),
+            Err(e) => { eprintln!("Error reading stream: {}", e) }
+        }
+    }
+}
+
+fn handle_connection(mut stream : TcpStream) -> Result<(), Box<dyn Error>>{
+    let mut buffer = [0; 512];
+    stream.read(&mut buffer)?;
+
+    let request_data = String::from_utf8_lossy(&buffer[..]);
+    println!("Request: {}", &request_data);
+
+    for &file in &FILE_LIST {
+        if request_data.starts_with(&format!("GET /{} ", file.0)) ||
+            request_data.starts_with(&format!("GET /{}?", file.0)) {
+            stream.write(b"HTTP/1.1 200 OK\r\n")?;
+            stream.write(format!("Content-type: {}\r\n\r\n", file.2).as_bytes())?;
+            let contents = fs::read_to_string(format!("interface/{}", file.1)).unwrap();
+            stream.write(contents.as_bytes()).unwrap();
+            return Ok(());
+        }
+    }
+
+    if !request_data.starts_with("GET /request/") {
+        return Ok(());
+    }
+
+    let request_content: &str = request_data.split(" ").collect::<Vec<&str>>()[1];
+    let requests = request_content.split("/").collect::<Vec<&str>>();
+
+    let module_path = format!("modules/{}.json", requests[3]);
+    let algebra_name = requests[4].to_string();
+    let max_degree = requests[5].parse::<i32>()?;
+
+    let config = rust_ext::Config {
+        module_path,
+        algebra_name,
+        max_degree,
+    };
+
+    let mut bundle = rust_ext::construct(&config)?;
+
+    stream.write(b"HTTP/1.1 200 OK\r\n")?;
+    stream.write(b"Content-type: text/event-stream\r\n\r\n")?;
+
+    let stream = Arc::new(Mutex::new(stream));
+
+    let stream_clone = Arc::clone(&stream);
+    let add_class = move |s: u32, t: i32, _name: &str| {
+        let clone = Arc::clone(&stream_clone);
+        thread::spawn(move || {
+            let mut strm = clone.lock().unwrap();
+            match strm.write(format!("event: addClass\r\ndata: {{\"s\": {}, \"t\": {}}}\r\n\r\n", s, t).as_bytes()) {
+                 Ok(_) => (),
+                 Err(_) => println!("Failed to send class")
+            };
+        });
+    };
+
+    let stream_clone = Arc::clone(&stream);
+    let add_structline = move |name : &str, source_s: u32, source_t: i32, source_idx: usize, target_s : u32, target_t : i32, target_idx : usize| {
+        let clone = Arc::clone(&stream_clone);
+        let name_c = name.to_string(); // need to do something to name so that what we pass to the thread has long enough lifetime.
+        thread::spawn(move || {
+            let mut strm = clone.lock().unwrap();
+            match strm.write(format!("event: addStructline\r\ndata: {{\"name\": \"{}\", \"source_s\": {}, \"source_t\": {}, \"source_idx\": {}, \"target_s\": {}, \"target_t\": {}, \"target_idx\": {}}}\r\n\r\n", name_c, source_s, source_t, source_idx, target_s, target_t, target_idx).as_bytes()) {
+                 Ok(_) => (),
+                 Err(_) => println!("Failed to send structline")
+            };
+        });
+    };
+
+    bundle.set_add_class(Some(Box::new(add_class)));
+    bundle.set_add_structline(Some(Box::new(add_structline)));
+
+    bundle.resolve_through_degree(max_degree);
+
+    stream.lock().unwrap().write(b"event: done")?;
+
+    println!("Stream close");
+    Ok(())
+}

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -182,6 +182,18 @@ impl<M : Module, F : ModuleHomomorphism<M, M>, CC : ChainComplex<M, F>> Resoluti
         }
     }
 
+    pub fn set_add_class(&mut self, add_class : Option<Box<dyn Fn(u32, i32, &str)>>) {
+        self.add_class = add_class;
+    }
+
+    pub fn set_add_structline(&mut self, add_structline : Option<Box<dyn Fn(
+            &str,
+            u32, i32, usize,
+            u32, i32, usize
+            )>>) {
+        self.add_structline = add_structline;
+    }
+
     pub fn add_structline(
             &self, 
             name : &str,


### PR DESCRIPTION
This is a pretty neat Ext resolver and a pretty awful web server.

The web server is single-threaded, which means it can only handle one session at a time. This causes issues when refreshing the page.

This uses server-sent events, which allows the server to push messages to the client, but not the other way round. This is currently not supported on Edge. On the other hand, I don't have a single clue how I can run this on a Windows machine (it's probably not that hard, but still). Server-sent events can also be polyfilled. There is an advanced version of server-sent events, namely WebSockets. This is more widely supported but is more complicated to use.

One critical flaw of the current program is that the resolution objects are dropped when the calculation finishes (and it then ends the session). This is not ideal, because later the client might want to request more information. However, this is not difficult to solve. We just pass the AlgebraicObjectBundle around.

A more serious problem is that the client misses some structlines (and maybe classes) every now and then. It is not always the same lines that are missed. I have no idea why. Currently these data are sent via a different thread. This can potentially be improved. One easy way to improve it is to spawn a single thread only and pass messages, instead of spawning a new thread for every class and structline.

My intention is, if we keep the server-sent events model, that clients have to wait for one calculation to be done before they can request the next (since some events will require a mutable borrow). They will make these requests by starting a new server-sent event stream, with the request encoded in the path. 