### PR TITLE
Allow running resolve_through_degree multiple times

### DIFF
--- a/ext-websocket/interface/display.js
+++ b/ext-websocket/interface/display.js
@@ -44,7 +44,7 @@ class StructlinePanel extends Panel.Panel {
 }
 
 export default class MyDisplay extends SidebarDisplay {
-    constructor(container, sseq) {
+    constructor(container, sseq, callbacks) {
         super(container, sseq);
 
         this.tooltip = new Tooltip(this);
@@ -65,6 +65,7 @@ export default class MyDisplay extends SidebarDisplay {
         this.runningSign.innerHTML = "Running...";
         this.sidebar.footer.addObject(this.runningSign);
 
+        this.sidebar.footer.addButton("Resolve further", callbacks["resolveFurther"]);
         this.sidebar.footer.addButton("Download SVG", () => this.downloadSVG("sseq.svg"));
         this.sidebar.footer.addButton("Save", () => this.sseq.download("sseq.json"));
     }

--- a/ext-websocket/src/main.rs
+++ b/ext-websocket/src/main.rs
@@ -56,9 +56,23 @@ impl ResolutionManager {
             let json : Value = serde_json::from_str(&msg).unwrap();// Implement proper error handling.
             match json["command"].as_str() {
                 Some("resolve") => manager.resolve(json)?,
+                Some("resolve_further") => manager.resolve_further(json)?,
                 Some("resolve_json") => manager.resolve_json(json)?,
                 _ => {println!("Ignoring message: {:#}", json);}
             };
+        }
+        Ok(())
+    }
+
+    /// Resolve existing resolution to a larger degree
+    fn resolve_further(&mut self, json : Value) -> Result<(), Box<dyn Error>> {
+        let max_degree = json["maxDegree"].as_i64().unwrap() as i32;
+        if let Some(bundle) = &self.bundle {
+            let mut resolution = bundle.resolution.borrow_mut();
+            resolution.resolve_through_degree(max_degree);
+
+            let data = json!({ "command": "complete" });
+            self.sender.send(data.to_string())?;
         }
         Ok(())
     }

--- a/ext-websocket/src/main.rs
+++ b/ext-websocket/src/main.rs
@@ -69,7 +69,7 @@ impl ResolutionManager {
         let max_degree = json["maxDegree"].as_i64().unwrap() as i32;
         let json_data = serde_json::from_str(json["data"].as_str().unwrap())?;
 
-        self.bundle = rust_ext::construct_from_json(json_data, algebra_name, max_degree).ok();
+        self.bundle = rust_ext::construct_from_json(json_data, algebra_name).ok();
 
         self.resolve_bundle(max_degree)
     }

--- a/src/chain_complex.rs
+++ b/src/chain_complex.rs
@@ -70,6 +70,4 @@ impl<M : Module> ChainComplex<OptionModule<M>, ZeroHomomorphism<OptionModule<M>,
             self.module.compute_basis(degree);
         }
     }
-
-
 }

--- a/src/fp_vector.rs
+++ b/src/fp_vector.rs
@@ -145,7 +145,7 @@ fn get_limb_bit_index_pair(p : u32, idx : usize) -> LimbBitIndexPair {
 }
 
 #[enum_dispatch]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum FpVector {
     FpVector2,
     FpVector3,
@@ -487,7 +487,7 @@ impl PartialEq for FpVector {
 
 impl Eq for FpVector {}
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct VectorContainer {
     dimension : usize,
     offset : usize,
@@ -496,22 +496,22 @@ pub struct VectorContainer {
     limbs : Vec<u64>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FpVector2 {
     vector_container : VectorContainer
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FpVector3 {
     vector_container : VectorContainer
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FpVector5 {
     vector_container : VectorContainer
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FpVectorGeneric {
     p : u32,
     vector_container : VectorContainer

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ pub fn construct_from_json(mut json : Value, algebra_name : String, max_degree :
     let algebra = Rc::new(algebra);
     let module = Rc::new(FiniteModule::from_json(Rc::clone(&algebra), &algebra_name, &mut json)?);
     let chain_complex = Rc::new(CCDZ::new(Rc::clone(&module)));
-    let resolution = Rc::new(RefCell::new(Resolution::new(Rc::clone(&chain_complex), max_degree, None, None)));
+    let resolution = Rc::new(RefCell::new(Resolution::new(Rc::clone(&chain_complex), None, None)));
     Ok(AlgebraicObjectsBundle {
         algebra,
         module,
@@ -103,7 +103,7 @@ pub fn run_define_module() -> Result<String, Box<dyn Error>> {
 
 pub fn run_resolve(config : &Config) -> Result<String, Box<dyn Error>> {
     let bundle = construct(config)?;
-    let resolution = bundle.resolution.borrow();
+    let mut resolution = bundle.resolution.borrow_mut();
     resolution.resolve_through_degree(config.max_degree);
     Ok(resolution.graded_dimension_string())
 }
@@ -126,7 +126,7 @@ pub fn run_test() {
     let decomposition = algebra.decompose_basis_element(60, idx);
     println!("decomposition : {:?}", decomposition);
 
-    return;
+//    return;
     let max_degree = 25;
     // let contents = std::fs::read_to_string("static/modules/S_3.json").unwrap();
     // S_3
@@ -138,8 +138,8 @@ pub fn run_test() {
     let algebra = Rc::new(AlgebraAny::from(AdemAlgebra::new(p, p != 2, false)));
     let module = Rc::new(FDModule::from_json(Rc::clone(&algebra), "adem", &mut json));
     let chain_complex = Rc::new(CCDZ::new(Rc::clone(&module)));
-    let resolution = Rc::new(Resolution::new(Rc::clone(&chain_complex), max_degree, None, None)); 
-    // resolution.resolve_through_degree(max_degree);
+    let resolution = Rc::new(RefCell::new(Resolution::new(Rc::clone(&chain_complex), None, None)));
+    // resolution.borrow_mut().resolve_through_degree(max_degree);
     // let f = ResolutionHomomorphism::new("test".to_string(), Rc::clone(&resolution), Rc::clone(&resolution), 1, 4);
     // let mut v = matrix::Matrix::new(p, 1, 1);
     // v[0].set_entry(0, 1);
@@ -149,11 +149,11 @@ pub fn run_test() {
     let mut res_with_maps = ResolutionWithChainMaps::new(Rc::clone(&resolution), Rc::clone(&resolution));
     let mut map_data = crate::matrix::Matrix::new(2, 1, 1);
     map_data[0].set_entry(0, 1);
-    res_with_maps.add_self_map(4, 12, "v_1".to_string(), map_data);
-    // res_with_maps.add_product(2, 12, 0, "beta".to_string());
-    // res_with_maps.add_product(2, 9, 0, "\\alpha_{2}".to_string());
+    // res_with_maps.add_self_map(4, 12, "v_1".to_string(), map_data);
+    res_with_maps.add_product(2, 12, 0, "beta".to_string());
+    res_with_maps.add_product(2, 9, 0, "\\alpha_{2}".to_string());
     res_with_maps.resolve_through_degree(max_degree);
-    println!("{}", resolution.graded_dimension_string());
+    println!("{}", resolution.borrow().graded_dimension_string());
 }
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,10 +72,10 @@ pub fn construct(config : &Config) -> Result<AlgebraicObjectsBundle<FiniteModule
     let contents = load_module_from_file(config)?;
     let json = serde_json::from_str(&contents)?;
 
-    construct_from_json(json, config.algebra_name.clone(), config.max_degree)
+    construct_from_json(json, config.algebra_name.clone())
 }
 
-pub fn construct_from_json(mut json : Value, algebra_name : String, max_degree : i32) -> Result<AlgebraicObjectsBundle<FiniteModule>, Box<dyn Error>> {
+pub fn construct_from_json(mut json : Value, algebra_name : String) -> Result<AlgebraicObjectsBundle<FiniteModule>, Box<dyn Error>> {
     let p = json["p"].as_u64().unwrap() as u32;
 
     // You need a box in order to allow for different possible types implementing the same trait

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -18,7 +18,7 @@ use std::fmt;
 /// In general, before one uses a matrix, they must run
 /// `fp_vector::initialize_limb_bit_index_table(p)`. This only has to be done once and will be
 /// omitted from all examples.
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Clone)]
 pub struct Matrix {
     p : u32,
     rows : usize,
@@ -435,7 +435,7 @@ impl Matrix {
 ///  * `column_to_pivot_row` - If the column is a pivot column, the entry is the row the pivot
 ///  corresponds to. If the column is not a pivot column, this is some negative number &mdash; not
 ///  necessarily -1!
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Subspace {
     pub matrix : Matrix,
     pub column_to_pivot_row : Vec<isize>

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -125,8 +125,11 @@ impl<M : Module, F : ModuleHomomorphism<M, M>, CC : ChainComplex<M, F>> Resoluti
         }
     }
 
-    pub fn resolve_through_degree(&mut self, degree : i32){
+    pub fn resolve_through_degree(&mut self, degree : i32) {
         let min_degree = self.get_min_degree();
+        if degree < self.next_degree {
+            return;
+        }
         self.extend_through_degree(degree);
 
         self.get_algebra().compute_basis(degree + 1);// because Adem has off-by-one

--- a/tests/resolve_iterate.rs
+++ b/tests/resolve_iterate.rs
@@ -1,0 +1,34 @@
+use rust_ext::Config;
+use rust_ext::construct_from_json;
+use rust_ext::load_module_from_file;
+use serde_json::Value;
+
+#[test]
+fn resolve_iterate() {
+    let path = std::path::PathBuf::from("static/modules");
+    let config = Config {
+        module_paths : vec![path],
+        module_file_name : "S_2".to_string(),
+        max_degree : 0, // Doesn't matter
+        algebra_name : String::from("adem")
+    };
+    let module_def = load_module_from_file(&config).unwrap();
+    let json : Value = serde_json::from_str(&module_def).unwrap();
+
+    let first = construct_from_json(json.clone(), "adem".to_string()).unwrap();
+    let second = construct_from_json(json, "adem".to_string()).unwrap();
+
+    first.resolution.borrow_mut().resolve_through_degree(20);
+
+    second.resolution.borrow_mut().resolve_through_degree(0);
+    second.resolution.borrow_mut().resolve_through_degree(5);
+    second.resolution.borrow_mut().resolve_through_degree(10);
+    second.resolution.borrow_mut().resolve_through_degree(10);
+    second.resolution.borrow_mut().resolve_through_degree(18);
+    second.resolution.borrow_mut().resolve_through_degree(14);
+    second.resolution.borrow_mut().resolve_through_degree(15);
+    second.resolution.borrow_mut().resolve_through_degree(20);
+
+    assert_eq!(first.resolution.borrow().graded_dimension_string(),
+               second.resolution.borrow().graded_dimension_string());
+}


### PR DESCRIPTION
I opted not to use `OnceVec`/`Mutex` in `Resolution`, because we eventually want to make `Resolution` mutable anyway so that we can add products etc (though technically we can still use OnceVec for that). It might still make sense to use OnceVec/Mutex because at the moment, what does or does not take a mutable borrow is pretty arbitrary.

I feel like the code isn't quite right for modules with non-zero `min_degree` in terms of how much we should to resolve in the `s` direction (it would still give valid results, just with weird cutoffs). Are there known use cases for a non-zero `min_degree`? If we insist `min_degree = 0`, we can simplify a lot of code (slightly).

I also think we should merge `Resolution` and `ResolutionWithChainMap`.